### PR TITLE
More detailed mirror lenses

### DIFF
--- a/src/wield/model/optics/alm/__init__.py
+++ b/src/wield/model/optics/alm/__init__.py
@@ -23,6 +23,7 @@ from .utils import (
     interface_ROC_AOI_X,
     REFL_ROC_X,
     REFL_ROC_Y,
+    substrate_propagation,
     str_m,
     str_D,
     unit_str,

--- a/src/wield/model/optics/alm/utils.py
+++ b/src/wield/model/optics/alm/utils.py
@@ -6,6 +6,20 @@
 # NOTICE: authors should document their contributions in concisely in NOTICE
 # with details inline in source files, comments, and docstrings.
 """
+Utilities for complex beam parameter propagation and string formatting
+
+Note that the ABCD convention used here for beam propagation differs from other references,
+e.g. Siegman. Here complex beam parameters q are propagated by
+
+q2 = (A * q1 + B) / (C * q1 + D)
+
+whereas in Siegman
+
+q2/n2 = (AA * (q1/n1) + BB) / (CC * (q1/n1) + DD)
+
+where n1 and n2 are the indices of refraction of the regions where the two beams are propagating.
+To convert between the two,
+A = AA, B = n1 * BB, C = CC / n2, and D = DD * (n1 / n2)
 """
 import numpy as np
 from wield.utilities.np import matrix_stack
@@ -135,6 +149,20 @@ def str_D(val, d=3, use_c=False, space=True):
 
 
 def interface_ROC(ROC_m, n_from, n_to, neg=False):
+    """
+    ABCD matrix for transmission through a curved surface at normal incidence
+
+    Parameters
+    ----------
+    ROC_m : float
+        Radius of curvature of the surface [m]
+    n_from : float
+        Index of refraction for the incident beam
+    n_to : float
+        Index of refraction for the transmitted beam
+    neg : bool; default: False
+        If True, reverses the sign of the radius of curvature
+    """
     nft = n_from / n_to
     if ROC_m is not None:
         if neg:
@@ -155,6 +183,23 @@ def interface_ROC(ROC_m, n_from, n_to, neg=False):
 
 
 def interface_ROC_AOI_Y(ROC_m, n_from, n_to, AOI_rad, neg=False):
+    """
+    ABCD matrix for transmission through a curved surface at arbitrary angle of incidence in the
+    saggital plane
+
+    Parameters
+    ----------
+    ROC_m : float
+        Radius of curvature of the surface [m]
+    n_from : float
+        Index of refraction for the incident beam
+    n_to : float
+        Index of refraction for the transmitted beam
+    AOI_rad : float
+        Angle of incidence [rad]
+    neg : bool; default: False
+        If True, reverses the sign of the radius of curvature
+    """
     nft = n_from / n_to
     if ROC_m is not None:
         adj = (1 - (nft * np.sin(AOI_rad)) ** 2) ** 0.5
@@ -176,6 +221,23 @@ def interface_ROC_AOI_Y(ROC_m, n_from, n_to, AOI_rad, neg=False):
 
 
 def interface_ROC_AOI_X(ROC_m, n_from, n_to, AOI_rad, neg=False):
+    """
+    ABCD matrix for transmission through a curved surface at arbitrary angle of incidence in the
+    tangential plane
+
+    Parameters
+    ----------
+    ROC_m : float
+        Radius of curvature of the surface [m]
+    n_from : float
+        Index of refraction for the incident beam
+    n_to : float
+        Index of refraction for the transmitted beam
+    AOI_rad : float
+        Angle of incidence [rad]
+    neg : bool; default: False
+        If True, reverses the sign of the radius of curvature
+    """
     nft = n_from / n_to
     if ROC_m is not None:
         adj = (1 - (nft * np.sin(AOI_rad)) ** 2) ** 0.5
@@ -200,6 +262,17 @@ def interface_ROC_AOI_X(ROC_m, n_from, n_to, AOI_rad, neg=False):
 
 
 def REFL_ROC_Y(ROC_m, AOI_rad):
+    """
+    ABCD matrix for reflection from a curved surface at arbitrary angle of incidence in the
+    saggital plane
+
+    Parameters
+    ----------
+    ROC_m : float
+        Radius of curvature of the surface [m]
+    AOI_rad : float
+        Angle of incidence [rad]
+    """
     if ROC_m is not None:
         return matrix_stack(
             [
@@ -217,6 +290,17 @@ def REFL_ROC_Y(ROC_m, AOI_rad):
 
 
 def REFL_ROC_X(ROC_m, AOI_rad):
+    """
+    ABCD matrix for reflection from a curved surface at arbitrary angle of incidence in the
+    tangential plane
+
+    Parameters
+    ----------
+    ROC_m : float
+        Radius of curvature of the surface [m]
+    AOI_rad : float
+        Angle of incidence [rad]
+    """
     if ROC_m is not None:
         return matrix_stack(
             [

--- a/src/wield/model/optics/mirror.py
+++ b/src/wield/model/optics/mirror.py
@@ -51,6 +51,9 @@ class MirrorBase(base.OpticalObject):
                 "ROC_B[m]",
                 "depth[m]",
                 "AOI[deg]",
+                "defocus[D]",
+                "defocusX[D]",
+                "defocusY[D]",
             ]
         )
 

--- a/src/wield/model/optics/mirror.py
+++ b/src/wield/model/optics/mirror.py
@@ -31,6 +31,7 @@ class MirrorBase(base.OpticalObject):
             self["defocus_B[D]"] = 0
             self["defocusX_B[D]"] = 0
             self["defocusY_B[D]"] = 0
+            self["substrate_lens[D]"] = 0
 
             self["annotate"] = "Mirror"
 
@@ -60,6 +61,7 @@ class MirrorBase(base.OpticalObject):
                 "defocus_B[D]",
                 "defocusX_B[D]",
                 "defocusY_B[D]",
+                "substrate_lens[D]",
             ]
         )
 
@@ -337,6 +339,7 @@ class MirrorBase(base.OpticalObject):
         defocusXB_D = manip.p["defocus_B[D]"] + manip.p["defocusX_B[D]"]
         defocusYA_D = manip.p["defocus[D]"] + manip.p["defocusY[D]"]
         defocusYB_D = manip.p["defocus_B[D]"] + manip.p["defocusY_B[D]"]
+        substrate_lens_D = manip.p["substrate_lens[D]"]
         matrixAD_X = matrix_stack([[1, 0], [defocusXA_D, 1]])
         matrixAD_Y = matrix_stack([[1, 0], [defocusYA_D, 1]])
         matrixBD_X = matrix_stack([[1, 0], [defocusXB_D, 1]])
@@ -355,7 +358,8 @@ class MirrorBase(base.OpticalObject):
             matrixAI_Y = alm.interface_ROC_AOI_Y(
                 ROC_A_m, n_from=n_A, n_to=n_I, AOI_rad=AOI_rad
             )
-            matrixII = matrix_stack([[1, depth_m], [0, 1]])
+            matrixII = alm.substrate_propagation(
+                depth_m, n0=n_I, defocus_D=substrate_lens_D)
             matrixIB_X = alm.interface_ROC_AOI_X(
                 ROC_B_m, n_from=n_I, n_to=n_B, AOI_rad=AOI_rad, neg=True
             )
@@ -364,7 +368,7 @@ class MirrorBase(base.OpticalObject):
             )
 
             def inc_builder(z):
-                return matrix_stack([[1, z], [0, 1]])
+                return alm.substrate_propagation(z, n0=n_I, defocus_D=substrate_lens_D)
 
             manip.set_Xincremental(
                 [
@@ -399,7 +403,8 @@ class MirrorBase(base.OpticalObject):
                 matrixAI = alm.interface_ROC_AOI_X(
                     ROC_A_m, n_from=n_A, n_to=n_I, AOI_rad=AOI_rad
                 )
-                matrixII = matrix_stack([[1, depth_m], [0, 1]])
+                matrixII = alm.substrate_propagation(
+                    depth_m, n0=n_I, defocus_D=substrate_lens_D)
                 matrixIB = alm.interface_ROC_AOI_X(
                     ROC_B_m, n_from=n_I, n_to=n_B, AOI_rad=AOI_rad, neg=True
                 )
@@ -415,11 +420,12 @@ class MirrorBase(base.OpticalObject):
                 depth_m = depth_m / np.cos(AOI_rad * n_A / n_I)
                 defocus_A_D = p["defocus[D]"] + p["defocusY[D]"]
                 defocus_B_D = p["defocus_B[D]"] + p["defocusY_B[D]"]
-
+                matrixII = alm.substrate_propagation(
+                    depth_m, n0=n_I, defocus_D=substrate_lens_D)
                 matrixAI = alm.interface_ROC_AOI_Y(
                     ROC_A_m, n_from=n_A, n_to=n_I, AOI_rad=AOI_rad
                 )
-                matrixII = matrix_stack([[1, depth_m], [0, 1]])
+
                 matrixIB = alm.interface_ROC_AOI_Y(
                     ROC_B_m, n_from=n_I, n_to=n_B, AOI_rad=AOI_rad, neg=True
                 )
@@ -441,7 +447,8 @@ class MirrorBase(base.OpticalObject):
             matrixBI_Y = alm.interface_ROC_AOI_Y(
                 ROC_B_m, n_from=n_B, n_to=n_I, AOI_rad=AOI_rad
             )
-            matrixII = matrix_stack([[1, depth_m], [0, 1]])
+            matrixII = alm.substrate_propagation(
+                depth_m, n0=n_I, defocus_D=substrate_lens_D)
             matrixIA_X = alm.interface_ROC_AOI_X(
                 ROC_A_m, n_from=n_I, n_to=n_A, AOI_rad=AOI_rad, neg=True
             )
@@ -450,7 +457,7 @@ class MirrorBase(base.OpticalObject):
             )
 
             def inc_builder(z):
-                return matrix_stack([[1, z], [0, 1]])
+                return alm.substrate_propagation(z, n0=n_I, defocus_D=substrate_lens_D)
 
             manip.set_Xincremental(
                 [
@@ -485,7 +492,8 @@ class MirrorBase(base.OpticalObject):
                 matrixBI = alm.interface_ROC_AOI_X(
                     ROC_B_m, n_from=n_B, n_to=n_I, AOI_rad=AOI_rad
                 )
-                matrixII = matrix_stack([[1, depth_m], [0, 1]])
+                matrixII = alm.substrate_propagation(
+                    depth_m, n0=n_I, defocus_D=substrate_lens_D)
                 matrixIA = alm.interface_ROC_AOI_X(
                     ROC_A_m, n_from=n_I, n_to=n_A, AOI_rad=AOI_rad, neg=True
                 )
@@ -505,7 +513,8 @@ class MirrorBase(base.OpticalObject):
                 matrixBI = alm.interface_ROC_AOI_Y(
                     ROC_B_m, n_from=n_B, n_to=n_I, AOI_rad=AOI_rad
                 )
-                matrixII = matrix_stack([[1, depth_m], [0, 1]])
+                matrixII = alm.substrate_propagation(
+                    depth_m, n0=n_I, defocus_D=substrate_lens_D)
                 matrixIA = alm.interface_ROC_AOI_Y(
                     ROC_A_m, n_from=n_I, n_to=n_A, AOI_rad=AOI_rad, neg=True
                 )
@@ -513,15 +522,14 @@ class MirrorBase(base.OpticalObject):
                 matrixAD = matrix_stack([[1, 0], [defocus_A_D, 1]])
                 return matrixAD @ matrixIA @ matrixII @ matrixBI @ matrixBD
 
-            manip.set_Xpropagator(p_builder_X)
-            manip.set_Ypropagator(p_builder_Y)
-
             def p_builderZ(p):
                 depth_m = p["depth[m]"]
                 AOI_rad = p["AOI[deg]"] * np.pi / 180
                 depth_m = depth_m / np.cos(AOI_rad * n_A / n_I)
                 return depth_m
 
+            manip.set_Xpropagator(p_builder_X)
+            manip.set_Ypropagator(p_builder_Y)
             manip.set_Zpropagator(
                 {"depth[m]": (1 / np.cos(AOI_rad * n_A / n_I), "AOI[deg]")}
             )
@@ -561,7 +569,8 @@ class MirrorBase(base.OpticalObject):
             matrixBI_Y = alm.interface_ROC_AOI_Y(
                 ROC_B_m, n_from=n_B, n_to=n_I, AOI_rad=AOI_rad
             )
-            matrixII = matrix_stack([[1, depth_m], [0, 1]])
+            matrixII = alm.substrate_propagation(
+                depth_m, n0=n_I, defocus_D=substrate_lens_D)
             if ROC_A_m is not None:
                 matrixR_X = alm.REFL_ROC_X(ROC_A_m, AOI_rad, neg=True)
                 matrixR_Y = alm.REFL_ROC_Y(ROC_A_m, AOI_rad, neg=True)
@@ -577,7 +586,7 @@ class MirrorBase(base.OpticalObject):
             )
 
             def inc_builder(z):
-                return matrix_stack([[1, z], [0, 1]])
+                return alm.substrate_propagation(z, n0=n_I, defocus_D=substrate_lens_D)
 
             manip.set_Xincremental(
                 [
@@ -616,7 +625,8 @@ class MirrorBase(base.OpticalObject):
                 matrixAD = matrix_stack([[1, 0], [defocus_A_D, 1]])
                 matrixBD = matrix_stack([[1, 0], [defocus_B_D, 1]])
                 matrixBI = alm.interface_ROC(ROC_B_m, n_from=n_B, n_to=n_I)
-                matrixII = matrix_stack([[1, depth_m], [0, 1]])
+                matrixII = alm.substrate_propagation(
+                    depth_m, n0=n_I, defocus_D=substrate_lens_D)
                 if ROC_A_m is not None:
                     matrixR = matrix_stack([[1, 0], [-2 / ROC_A_m, 1]])
                 else:
@@ -637,7 +647,8 @@ class MirrorBase(base.OpticalObject):
                 matrixAD = matrix_stack([[1, 0], [defocus_A_D, 1]])
                 matrixBD = matrix_stack([[1, 0], [defocus_B_D, 1]])
                 matrixBI = alm.interface_ROC(ROC_B_m, n_from=n_B, n_to=n_I)
-                matrixII = matrix_stack([[1, depth_m], [0, 1]])
+                matrixII = alm.substrate_propagation(
+                    depth_m, n0=n_I, defocus_D=substrate_lens_D)
                 if ROC_A_m is not None:
                     matrixR = matrix_stack([[1, 0], [-2 / ROC_A_m, 1]])
                 else:

--- a/src/wield/model/optics/thin_lens.py
+++ b/src/wield/model/optics/thin_lens.py
@@ -91,6 +91,9 @@ class ThinLens(base.OpticalObject):
 
 
 class ThinMirror(base.OpticalObject):
+    """
+    A perfectly reflective thin mirror.
+    """
     def __init__(self):
         super(ThinMirror, self).__init__()
         with self._internal():


### PR DESCRIPTION
The existing code has extra defocus applied on reflection from mirrors. This pull request makes the following additions to model more detailed mirror lenses.

1. The defocus parameters are added to `values_settable` for mirrors as they were only previously in thin mirrors.
2. The same defocus applied on reflection is applied on transmission.
3. Astigmatism and AOI effects were added to reflection from the back of a mirror.
4. Different defocus can be specified on the front and back surface of a mirror just as radii of curvature can be different for the two sides.
5. Propagation through a substrate is generalized to include a possible quadratic substrate lens which is modeled as a Gaussian duct. http://rezonator.orion-project.org/help/matrix/ElemThermoMedium.html

The extra lensing is useful for separately modeling different surface deformations on each side of an optic and a bulk thermal lens.